### PR TITLE
add explanation about user

### DIFF
--- a/docs/zigbee-to-mqtt.md
+++ b/docs/zigbee-to-mqtt.md
@@ -260,7 +260,7 @@ WorkingDirectory=/opt/zigbee2mqtt
 StandardOutput=inherit
 StandardError=inherit
 Restart=always
-User=ubuntu
+User=<YOUR_USER_HERE>
 
 [Install]
 WantedBy=multi-user.target
@@ -268,7 +268,13 @@ WantedBy=multi-user.target
 
 </code-helper>
 
-Verify that the configuration works:
+<robo-wiki-note type="note">
+
+If you don't know your username, use `whoami` command.
+
+</robo-wiki-note>
+
+Save file and verify that the configuration works:
 
 <code-helper additionalLine="rasppi_username@rasppi_hostname">
 


### PR DESCRIPTION
In zigbee2mqtt article systemd service doesn't provide user explanation. 